### PR TITLE
Add a default connector plugin

### DIFF
--- a/src/connectors/in-memory.ts
+++ b/src/connectors/in-memory.ts
@@ -1,0 +1,35 @@
+import { ISecret, ISecretsConnector } from '../token';
+
+/**
+ * An in memory password connector to store passwords during the session.
+ * Refreshing the page clear the passwords.
+ *
+ * This is the default implementation of ISecretsConnector.
+ */
+export class InMemoryConnector implements ISecretsConnector {
+  async fetch(id: string): Promise<ISecret | undefined> {
+    return this._secrets.get(id);
+  }
+
+  async save(id: string, value: ISecret): Promise<any> {
+    this._secrets.set(id, value);
+  }
+
+  async remove(id: string): Promise<any> {
+    this._secrets.delete(id);
+  }
+
+  async list(
+    query?: string | undefined
+  ): Promise<{ ids: string[]; values: ISecret[] }> {
+    const ids: string[] = [];
+    this._secrets.forEach((value, key) => {
+      if (value.namespace === query) {
+        ids.push(key);
+      }
+    });
+    return { ids, values: [] };
+  }
+
+  private _secrets = new Map<string, ISecret>();
+}

--- a/src/connectors/in-memory.ts
+++ b/src/connectors/in-memory.ts
@@ -23,12 +23,14 @@ export class InMemoryConnector implements ISecretsConnector {
     query?: string | undefined
   ): Promise<{ ids: string[]; values: ISecret[] }> {
     const ids: string[] = [];
+    const values: ISecret[] = [];
     this._secrets.forEach((value, key) => {
       if (value.namespace === query) {
         ids.push(key);
+        values.push(value);
       }
     });
-    return { ids, values: [] };
+    return { ids, values };
   }
 
   private _secrets = new Map<string, ISecret>();

--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,0 +1,2 @@
+export * from './in-memory';
+export * from './local-storage';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,12 +4,27 @@ import {
 } from '@jupyterlab/application';
 import { SecretsManager } from './manager';
 import { ISecretsConnector, ISecretsManager } from './token';
+import { InMemoryConnector } from './connectors';
 
 /**
- * Initialization data for the jupyter-secrets-manager extension.
+ * A basic secret connector extension, that should be disabled to provide a new
+ * connector.
  */
-const plugin: JupyterFrontEndPlugin<ISecretsManager> = {
-  id: 'jupyter-secrets-manager:plugin',
+const inMemoryConnector: JupyterFrontEndPlugin<ISecretsConnector> = {
+  id: 'jupyter-secrets-manager:connector',
+  description: 'A JupyterLab extension to manage secrets.',
+  autoStart: true,
+  provides: ISecretsConnector,
+  activate: (app: JupyterFrontEnd): ISecretsConnector => {
+    return new InMemoryConnector();
+  }
+};
+
+/**
+ * The secret manager extension.
+ */
+const manager: JupyterFrontEndPlugin<ISecretsManager> = {
+  id: 'jupyter-secrets-manager:manager',
   description: 'A JupyterLab extension to manage secrets.',
   autoStart: true,
   provides: ISecretsManager,
@@ -23,6 +38,6 @@ const plugin: JupyterFrontEndPlugin<ISecretsManager> = {
   }
 };
 
-export * from './connectors/local-storage';
+export * from './connectors';
 export * from './token';
-export default plugin;
+export default [inMemoryConnector, manager];


### PR DESCRIPTION
This PR adds a default connector plugin, storing the password in memory.

The passwords live only during the current session.