### PR TITLE
Allow the DataConnector to partially implements IDataConnector

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -10,24 +10,37 @@ export namespace SecretsManager {
     connector: ISecretsConnector;
   }
 }
+
 export class SecretsManager implements ISecretsManager {
   constructor(options: SecretsManager.IOptions) {
     this._connector = options.connector;
   }
 
   async get(id: string): Promise<ISecret | undefined> {
+    if (!this._connector.fetch) {
+      return;
+    }
     return this._connector.fetch(id);
   }
 
   async set(id: string, secret: ISecret): Promise<void> {
+    if (!this._connector.save) {
+      return;
+    }
     this._connector.save(id, secret);
   }
 
   async remove(id: string): Promise<void> {
+    if (!this._connector.remove) {
+      return;
+    }
     this._connector.remove(id);
   }
 
-  async list(namespace: string): Promise<ISecretsList> {
+  async list(namespace: string): Promise<ISecretsList | undefined> {
+    if (!this._connector.list) {
+      return;
+    }
     return await this._connector.list(namespace);
   }
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -7,7 +7,7 @@ export interface ISecret {
   value: string;
 }
 
-export interface ISecretsConnector extends IDataConnector<ISecret> {}
+export interface ISecretsConnector extends Partial<IDataConnector<ISecret>> {}
 export interface ISecretsList<T = ISecret> {
   ids: string[];
   values: T[];
@@ -22,7 +22,7 @@ export interface ISecretsManager {
   get(id: string): Promise<ISecret | undefined>;
   set(id: string, secret: ISecret): Promise<void>;
   remove(id: string): Promise<void>;
-  list(namespace: string): Promise<ISecretsList>;
+  list(namespace: string): Promise<ISecretsList | undefined>;
   attach(
     namespace: string,
     id: string,


### PR DESCRIPTION
This PR allows the `DataConnector` (provided by third party extension) to partially implement the `IDataConnector` interface.

> about the `ISecretsConnector`, could we relax it so that only fetch is required?
> for the read-only secret manager

*originally posted by @trungleduc*