### PR TITLE
Fix the detachAll method

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -78,18 +78,23 @@ export class SecretsManager implements ISecretsManager {
 
   detach(namespace: string, id: string): void {
     const attachedId = `${namespace}:${id}`;
+    this._detach(attachedId);
+  }
+
+  async detachAll(namespace: string): Promise<void> {
+    for (const id of this._attachedInputs.keys()) {
+      if (id.startsWith(`${namespace}:`)) {
+        this._detach(id);
+      }
+    }
+  }
+
+  private _detach(attachedId: string): void {
     const input = this._attachedInputs.get(attachedId);
     if (input) {
       input.removeEventListener('change', this._onchange);
     }
     this._attachedInputs.delete(attachedId);
-  }
-
-  async detachAll(namespace: string): Promise<void> {
-    const attachedIds = await this.list(namespace);
-    attachedIds.ids.forEach(id => {
-      this.detach(namespace, id);
-    });
   }
 
   private _connector: ISecretsConnector;

--- a/src/token.ts
+++ b/src/token.ts
@@ -28,9 +28,9 @@ export interface ISecretsManager {
     id: string,
     input: HTMLInputElement,
     callback?: (value: string) => void
-  ): void;
+  ): Promise<void>;
   detach(namespace: string, id: string): void;
-  detachAll(namespace: string): void;
+  detachAll(namespace: string): Promise<void>;
 }
 
 export const ISecretsManager = new Token<ISecretsManager>(


### PR DESCRIPTION
This PR fixes the `detachAll()` method of the `SecretManager`.

Previously it was using the list of registered passwords to detach inputs from the manager, instead of using the list of attached inputs. Also the ID passed to the `detach()` method was not the good one.