### PR TITLE
Add the namespace argument in public functions accessing the secrets

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -5,38 +5,46 @@ import {
   ISecretsManager
 } from './token';
 
+/**
+ * The secrets manager namespace.
+ */
 export namespace SecretsManager {
+  /**
+   * Secrets manager constructor's options.
+   */
   export interface IOptions {
     connector: ISecretsConnector;
   }
 }
 
+/**
+ * The default secrets manager implementation.
+ */
 export class SecretsManager implements ISecretsManager {
+  /**
+   * the secrets manager constructor.
+   */
   constructor(options: SecretsManager.IOptions) {
     this._connector = options.connector;
   }
 
-  async get(id: string): Promise<ISecret | undefined> {
-    if (!this._connector.fetch) {
-      return;
-    }
-    return this._connector.fetch(id);
+  /**
+   * Get a secret given its namespace and ID.
+   */
+  async get(namespace: string, id: string): Promise<ISecret | undefined> {
+    return this._get(Private.buildSecretId(namespace, id));
   }
 
-  async set(id: string, secret: ISecret): Promise<void> {
-    if (!this._connector.save) {
-      return;
-    }
-    this._connector.save(id, secret);
+  /**
+   * Set a secret given its namespace and ID.
+   */
+  async set(namespace: string, id: string, secret: ISecret): Promise<any> {
+    return this._set(Private.buildSecretId(namespace, id), secret);
   }
 
-  async remove(id: string): Promise<void> {
-    if (!this._connector.remove) {
-      return;
-    }
-    this._connector.remove(id);
-  }
-
+  /**
+   * List the secrets for a namespace as a ISecretsList.
+   */
   async list(namespace: string): Promise<ISecretsList | undefined> {
     if (!this._connector.list) {
       return;
@@ -44,26 +52,25 @@ export class SecretsManager implements ISecretsManager {
     return await this._connector.list(namespace);
   }
 
-  private _onchange = (e: Event): void => {
-    const target = e.target as HTMLInputElement;
-    const attachedId = target.dataset.secretsId;
-    if (attachedId) {
-      const splitId = attachedId.split(':');
-      const namespace = splitId.shift();
-      const id = splitId.join(':');
-      if (namespace && id) {
-        this.set(attachedId, { namespace, id, value: target.value });
-      }
-    }
-  };
+  /**
+   * Remove a secret given its namespace and ID.
+   */
+  async remove(namespace: string, id: string): Promise<void> {
+    return this._remove(Private.buildSecretId(namespace, id));
+  }
 
+  /**
+   * Attach an input to the secrets manager, with its namespace and ID values.
+   * An optional callback function can be attached too, which be called when the input
+   * is programmatically filled.
+   */
   async attach(
     namespace: string,
     id: string,
     input: HTMLInputElement,
     callback?: (value: string) => void
   ): Promise<void> {
-    const attachedId = `${namespace}:${id}`;
+    const attachedId = Private.buildSecretId(namespace, id);
     const attachedInput = this._attachedInputs.get(attachedId);
 
     // Detach the previous input.
@@ -73,7 +80,7 @@ export class SecretsManager implements ISecretsManager {
     this._attachedInputs.set(attachedId, input);
 
     input.dataset.secretsId = attachedId;
-    const secret = await this.get(attachedId);
+    const secret = await this._get(attachedId);
     if (!input.value && secret) {
       // Fill the password if the input is empty and a value is fetched by the data
       // connector.
@@ -84,16 +91,21 @@ export class SecretsManager implements ISecretsManager {
       }
     } else if (input.value && input.value !== secret?.value) {
       // Otherwise save the current input value using the data connector.
-      this.set(attachedId, { namespace, id, value: input.value });
+      this._set(attachedId, { namespace, id, value: input.value });
     }
     input.addEventListener('change', this._onchange);
   }
 
+  /**
+   * Detach the input previously attached with its namespace and ID.
+   */
   detach(namespace: string, id: string): void {
-    const attachedId = `${namespace}:${id}`;
-    this._detach(attachedId);
+    this._detach(Private.buildSecretId(namespace, id));
   }
 
+  /**
+   * Detach all attached input for a namespace.
+   */
   async detachAll(namespace: string): Promise<void> {
     for (const id of this._attachedInputs.keys()) {
       if (id.startsWith(`${namespace}:`)) {
@@ -102,6 +114,55 @@ export class SecretsManager implements ISecretsManager {
     }
   }
 
+  /**
+   * Actually fetch the secret from the connector.
+   */
+  private async _get(id: string): Promise<ISecret | undefined> {
+    if (!this._connector.fetch) {
+      return;
+    }
+    return this._connector.fetch(id);
+  }
+
+  /**
+   * Actually save the secret using the connector.
+   */
+  private async _set(id: string, secret: ISecret): Promise<any> {
+    if (!this._connector.save) {
+      return;
+    }
+    return this._connector.save(id, secret);
+  }
+
+  /**
+   * Actually remove the secrets using the connector.
+   */
+  async _remove(id: string): Promise<void> {
+    if (!this._connector.remove) {
+      return;
+    }
+    this._connector.remove(id);
+  }
+
+  /**
+   * Function triggered when the input value changed.
+   */
+  private _onchange = (e: Event): void => {
+    const target = e.target as HTMLInputElement;
+    const attachedId = target.dataset.secretsId;
+    if (attachedId) {
+      const splitId = attachedId.split(':');
+      const namespace = splitId.shift();
+      const id = splitId.join(':');
+      if (namespace && id) {
+        this._set(attachedId, { namespace, id, value: target.value });
+      }
+    }
+  };
+
+  /**
+   * Actually detach of an input.
+   */
   private _detach(attachedId: string): void {
     const input = this._attachedInputs.get(attachedId);
     if (input) {
@@ -112,4 +173,13 @@ export class SecretsManager implements ISecretsManager {
 
   private _connector: ISecretsConnector;
   private _attachedInputs = new Map<string, HTMLInputElement>();
+}
+
+namespace Private {
+  /**
+   * Build the secret id from the namespace and id.
+   */
+  export function buildSecretId(namespace: string, id: string): string {
+    return `${namespace}:${id}`;
+  }
 }

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,38 +1,80 @@
 import { IDataConnector } from '@jupyterlab/statedb';
 import { Token } from '@lumino/coreutils';
 
+/**
+ * The secret object interface.
+ */
 export interface ISecret {
   namespace: string;
   id: string;
   value: string;
 }
 
+/**
+ * The secret connector interface.
+ */
 export interface ISecretsConnector extends Partial<IDataConnector<ISecret>> {}
+
+/**
+ * The secrets list interface.
+ */
 export interface ISecretsList<T = ISecret> {
   ids: string[];
   values: T[];
 }
 
+/**
+ * The secrets connector token.
+ */
 export const ISecretsConnector = new Token<ISecretsConnector>(
   'jupyter-secret-manager:connector',
-  'The secrets manager connector'
+  'The secrets connector'
 );
 
+/**
+ * The secrets manager interface.
+ */
 export interface ISecretsManager {
-  get(id: string): Promise<ISecret | undefined>;
-  set(id: string, secret: ISecret): Promise<void>;
-  remove(id: string): Promise<void>;
+  /**
+   * Get a secret given its namespace and ID.
+   */
+  get(namespace: string, id: string): Promise<ISecret | undefined>;
+  /**
+   * Set a secret given its namespace and ID.
+   */
+  set(namespace: string, id: string, secret: ISecret): Promise<any>;
+  /**
+   * Remove a secret given its namespace and ID.
+   */
+  remove(namespace: string, id: string): Promise<void>;
+  /**
+   * List the secrets for a namespace as a ISecretsList.
+   */
   list(namespace: string): Promise<ISecretsList | undefined>;
+  /**
+   * Attach an input to the secrets manager, with its namespace and ID values.
+   * An optional callback function can be attached too, which be called when the input
+   * is programmatically filled.
+   */
   attach(
     namespace: string,
     id: string,
     input: HTMLInputElement,
     callback?: (value: string) => void
   ): Promise<void>;
+  /**
+   * Detach the input previously attached with its namespace and ID.
+   */
   detach(namespace: string, id: string): void;
+  /**
+   * Detach all attached input for a namespace.
+   */
   detachAll(namespace: string): Promise<void>;
 }
 
+/**
+ * The secrets manager token.
+ */
 export const ISecretsManager = new Token<ISecretsManager>(
   'jupyter-secret-manager:manager',
   'The secrets manager'


### PR DESCRIPTION
This PR adds the namespace argument in the public functions of the `SecretsManager`.
This is mandatory to actually fetch the password from an extension.

Most of the other changes are about adding some docstring.