### PR TITLE
Isolate secrets from others extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     },
     "dependencies": {
         "@jupyterlab/application": "^4.0.0",
+        "@jupyterlab/coreutils": "^6.0.0",
         "@jupyterlab/statedb": "^4.0.0",
         "@lumino/algorithm": "^2.0.0",
         "@lumino/coreutils": "^2.1.2"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,5 +35,6 @@ const manager: JupyterFrontEndPlugin<ISecretsManager> = {
 };
 
 export * from './connectors';
+export * from './manager';
 export * from './token';
 export default [inMemoryConnector, manager];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,20 +3,20 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { SecretsManager } from './manager';
-import { ISecretsConnector, ISecretsManager } from './token';
+import { ISecretsManager } from './token';
 import { InMemoryConnector } from './connectors';
 
 /**
  * A basic secret connector extension, that should be disabled to provide a new
  * connector.
  */
-const inMemoryConnector: JupyterFrontEndPlugin<ISecretsConnector> = {
+const inMemoryConnector: JupyterFrontEndPlugin<void> = {
   id: 'jupyter-secrets-manager:connector',
   description: 'A JupyterLab extension to manage secrets.',
   autoStart: true,
-  provides: ISecretsConnector,
-  activate: (app: JupyterFrontEnd): ISecretsConnector => {
-    return new InMemoryConnector();
+  requires: [ISecretsManager],
+  activate: (app: JupyterFrontEnd, manager: ISecretsManager): void => {
+    manager.setConnector(new InMemoryConnector());
   }
 };
 
@@ -28,13 +28,9 @@ const manager: JupyterFrontEndPlugin<ISecretsManager> = {
   description: 'A JupyterLab extension to manage secrets.',
   autoStart: true,
   provides: ISecretsManager,
-  requires: [ISecretsConnector],
-  activate: (
-    app: JupyterFrontEnd,
-    connector: ISecretsConnector
-  ): ISecretsManager => {
+  activate: (app: JupyterFrontEnd): ISecretsManager => {
     console.log('JupyterLab extension jupyter-secrets-manager is activated!');
-    return new SecretsManager({ connector });
+    return new SecretsManager();
   }
 };
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -26,7 +26,7 @@ export class SecretsManager implements ISecretsManager {
    *
    * NOTE:
    * If several extensions try to set the connector, the manager will be locked.
-   * This is to prevent malicious extensions to get passwords when they are saved.
+   * This is to prevent misconfiguration of competing plugins or MITM attacks.
    */
   setConnector(value: ISecretsConnector): void {
     Private.setConnector(value);
@@ -179,6 +179,9 @@ export class SecretsManager implements ISecretsManager {
   private _storing: PromiseDelegate<void>;
 }
 
+/**
+ * Freeze the secrets manager methods, to prevent extensions from overwriting them.
+ */
 Object.freeze(SecretsManager.prototype);
 
 /**

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -1,3 +1,5 @@
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { PromiseDelegate } from '@lumino/coreutils';
 
 import {
@@ -6,18 +8,6 @@ import {
   ISecretsList,
   ISecretsManager
 } from './token';
-
-/**
- * The secrets manager namespace.
- */
-export namespace SecretsManager {
-  /**
-   * Secrets manager constructor's options.
-   */
-  export interface IOptions {
-    connector: ISecretsConnector;
-  }
-}
 
 /**
  * The default secrets manager implementation.
@@ -39,21 +29,36 @@ export class SecretsManager implements ISecretsManager {
   /**
    * Get a secret given its namespace and ID.
    */
-  async get(namespace: string, id: string): Promise<ISecret | undefined> {
-    return this._get(Private.buildSecretId(namespace, id));
+  async get(
+    token: symbol,
+    namespace: string,
+    id: string
+  ): Promise<ISecret | undefined> {
+    this._check(token, namespace);
+    return this._get(Private.buildConnectorId(namespace, id));
   }
 
   /**
    * Set a secret given its namespace and ID.
    */
-  async set(namespace: string, id: string, secret: ISecret): Promise<any> {
-    return this._set(Private.buildSecretId(namespace, id), secret);
+  async set(
+    token: symbol,
+    namespace: string,
+    id: string,
+    secret: ISecret
+  ): Promise<any> {
+    this._check(token, namespace);
+    return this._set(Private.buildConnectorId(namespace, id), secret);
   }
 
   /**
    * List the secrets for a namespace as a ISecretsList.
    */
-  async list(namespace: string): Promise<ISecretsList | undefined> {
+  async list(
+    token: symbol,
+    namespace: string
+  ): Promise<ISecretsList | undefined> {
+    this._check(token, namespace);
     if (!this._connector.list) {
       return;
     }
@@ -64,8 +69,9 @@ export class SecretsManager implements ISecretsManager {
   /**
    * Remove a secret given its namespace and ID.
    */
-  async remove(namespace: string, id: string): Promise<void> {
-    return this._remove(Private.buildSecretId(namespace, id));
+  async remove(token: symbol, namespace: string, id: string): Promise<void> {
+    this._check(token, namespace);
+    return this._remove(Private.buildConnectorId(namespace, id));
   }
 
   /**
@@ -74,17 +80,19 @@ export class SecretsManager implements ISecretsManager {
    * is programmatically filled.
    */
   async attach(
+    token: symbol,
     namespace: string,
     id: string,
     input: HTMLInputElement,
     callback?: (value: string) => void
   ): Promise<void> {
-    const attachedId = Private.buildSecretId(namespace, id);
+    this._check(token, namespace);
+    const attachedId = Private.buildConnectorId(namespace, id);
     const attachedInput = this._attachedInputs.get(attachedId);
 
     // Detach the previous input.
     if (attachedInput) {
-      this.detach(namespace, id);
+      this.detach(token, namespace, id);
     }
     this._attachedInputs.set(attachedId, input);
 
@@ -108,14 +116,16 @@ export class SecretsManager implements ISecretsManager {
   /**
    * Detach the input previously attached with its namespace and ID.
    */
-  detach(namespace: string, id: string): void {
-    this._detach(Private.buildSecretId(namespace, id));
+  detach(token: symbol, namespace: string, id: string): void {
+    this._check(token, namespace);
+    this._detach(Private.buildConnectorId(namespace, id));
   }
 
   /**
    * Detach all attached input for a namespace.
    */
-  async detachAll(namespace: string): Promise<void> {
+  async detachAll(token: symbol, namespace: string): Promise<void> {
+    this._check(token, namespace);
     for (const id of this._attachedInputs.keys()) {
       if (id.startsWith(`${namespace}:`)) {
         this._detach(id);
@@ -184,16 +194,107 @@ export class SecretsManager implements ISecretsManager {
     this._attachedInputs.delete(attachedId);
   }
 
+  private _check(token: symbol, namespace: string): void {
+    if (Private.isLocked() || Private.namespace.get(token) !== namespace) {
+      throw new Error(
+        `The secrets namespace ${namespace} is not available with the provided token`
+      );
+    }
+  }
+
   private _connector: ISecretsConnector;
   private _attachedInputs = new Map<string, HTMLInputElement>();
   private _ready: PromiseDelegate<void>;
 }
 
+/**
+ * The secrets manager namespace.
+ */
+export namespace SecretsManager {
+  /**
+   * Secrets manager constructor's options.
+   */
+  export interface IOptions {
+    connector: ISecretsConnector;
+  }
+
+  /**
+   * A function that protect the secrets namespaces from other plugins.
+   *
+   * @param id - the secrets namespace, which must match the plugin ID to prevent an
+   * extension to use an other extension namespace.
+   * @param factory - a plugin factory, taking a symbol as argument and returning a
+   * plugin.
+   * @returns - the plugin to activate.
+   */
+  export function sign<T>(
+    id: string,
+    factory: ISecretsManager.PluginFactory<T>
+  ): JupyterFrontEndPlugin<T> {
+    const { lock, isLocked, namespace: plugins, symbols } = Private;
+    const { isDisabled } = PageConfig.Extension;
+    if (isLocked()) {
+      throw new Error('Secret registry is locked, check errors.');
+    }
+    if (isDisabled('jupyter-secrets-manager:manager')) {
+      lock('Secret registry is disabled.');
+    }
+    if (isDisabled(id)) {
+      lock(`Sign error: plugin ${id} is disabled.`);
+    }
+    if (symbols.has(id)) {
+      lock(`Sign error: another plugin signed as "${id}".`);
+    }
+    const token = Symbol(id);
+    const plugin = factory(token);
+    if (id !== plugin.id) {
+      lock(`Sign error: plugin ID mismatch "${plugin.id}"≠"${id}".`);
+    }
+    plugins.set(token, id);
+    symbols.set(id, token);
+    return plugin;
+  }
+}
+
 namespace Private {
+  /**
+   * Internal 'locked' status.
+   */
+  let locked: boolean = false;
+
+  /**
+   * The namespace associated to a symbol.
+   */
+  export const namespace = new Map<symbol, string>();
+
+  /**
+   * The symbol associated to a namespace.
+   */
+  export const symbols = new Map<string, symbol>();
+
+  /**
+   * Lock the manager.
+   *
+   * @param message - the error message to throw.
+   */
+  export function lock(message: string) {
+    locked = true;
+    throw new Error(message);
+  }
+
+  /**
+   * Check if the manager is locked.
+   *
+   * @returns - whether the manager is locked or not.
+   */
+  export function isLocked(): boolean {
+    return locked;
+  }
+
   /**
    * Build the secret id from the namespace and id.
    */
-  export function buildSecretId(namespace: string, id: string): string {
+  export function buildConnectorId(namespace: string, id: string): string {
     return `${namespace}:${id}`;
   }
 }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -112,7 +112,8 @@ export class SecretsManager implements ISecretsManager {
     }
     this._attachedInputs.set(attachedId, input);
 
-    input.dataset.secretsId = attachedId;
+    input.dataset.namespace = namespace;
+    input.dataset.secretsId = id;
     const secret = await this._get(attachedId);
     if (!input.value && secret) {
       // Fill the password if the input is empty and a value is fetched by the data
@@ -189,15 +190,12 @@ export class SecretsManager implements ISecretsManager {
     // Reset the storing status.
     this._storing = new PromiseDelegate<void>();
     const target = e.target as HTMLInputElement;
-    const attachedId = target.dataset.secretsId;
-    if (attachedId) {
-      const splitId = attachedId.split(':');
-      const namespace = splitId.shift();
-      const id = splitId.join(':');
-      if (namespace && id) {
-        await this._ready.promise;
-        await this._set(attachedId, { namespace, id, value: target.value });
-      }
+    const namespace = target.dataset.namespace;
+    const id = target.dataset.secretsId;
+    if (namespace && id) {
+      const attachedId = Private.buildConnectorId(namespace, id);
+      await this._ready.promise;
+      await this._set(attachedId, { namespace, id, value: target.value });
     }
     // resolve the storing status.
     this._storing.resolve();

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -129,7 +129,7 @@ export class SecretsManager implements ISecretsManager {
   /**
    * Detach the input previously attached with its namespace and ID.
    */
-  detach(token: symbol, namespace: string, id: string): void {
+  async detach(token: symbol, namespace: string, id: string): Promise<void> {
     Private.checkNamespace(token, namespace);
     this._detach(Private.buildConnectorId(namespace, id));
   }

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -29,9 +29,6 @@ export class SecretsManager implements ISecretsManager {
    * This is to prevent malicious extensions to get passwords when they are saved.
    */
   setConnector(value: ISecretsConnector): void {
-    if (Private.getConnector() !== null) {
-      Private.lock('A connector was already provided to the secrets manager');
-    }
     Private.setConnector(value);
   }
 
@@ -77,7 +74,7 @@ export class SecretsManager implements ISecretsManager {
       return;
     }
     await this._ready.promise;
-    return await connector.list(namespace);
+    return connector.list(namespace);
   }
 
   /**
@@ -178,7 +175,7 @@ export class SecretsManager implements ISecretsManager {
     if (!connector?.remove) {
       return;
     }
-    connector.remove(id);
+    return connector.remove(id);
   }
 
   private _onInput = async (e: Event): Promise<void> => {
@@ -228,7 +225,8 @@ export class SecretsManager implements ISecretsManager {
  */
 export namespace SecretsManager {
   /**
-   * A function that protect the secrets namespaces from other plugins.
+   * A function that protects the secrets namespace of the signed plugin from
+   * other plugins.
    *
    * @param id - the secrets namespace, which must match the plugin ID to prevent an
    * extension to use an other extension namespace.
@@ -243,7 +241,7 @@ export namespace SecretsManager {
     const { lock, isLocked, namespace: plugins, symbols } = Private;
     const { isDisabled } = PageConfig.Extension;
     if (isLocked()) {
-      throw new Error('Secret registry is locked, check errors.');
+      throw new Error('Secrets manager is locked, check errors.');
     }
     if (isDisabled('jupyter-secrets-manager:manager')) {
       lock('Secret registry is disabled.');
@@ -309,6 +307,9 @@ namespace Private {
    * Set the connector.
    */
   export function setConnector(value: ISecretsConnector) {
+    if (connector !== null) {
+      lock('A secrets manager connector already exists.');
+    }
     connector = value;
   }
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -25,17 +25,17 @@ export interface ISecretsList<T = ISecret> {
 }
 
 /**
- * The secrets connector token.
- */
-export const ISecretsConnector = new Token<ISecretsConnector>(
-  'jupyter-secret-manager:connector',
-  'The secrets connector'
-);
-
-/**
  * The secrets manager interface.
  */
 export interface ISecretsManager {
+  /**
+   * Set the connector to use with the manager.
+   *
+   * NOTE:
+   * If several extensions try to set the connector, the manager will be locked.
+   * This is to prevent malicious extensions to get passwords when they are saved.
+   */
+  setConnector(value: ISecretsConnector): void;
   /**
    * Get a secret given its namespace and ID.
    */

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,3 +1,4 @@
+import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 import { IDataConnector } from '@jupyterlab/statedb';
 import { Token } from '@lumino/coreutils';
 
@@ -38,25 +39,35 @@ export interface ISecretsManager {
   /**
    * Get a secret given its namespace and ID.
    */
-  get(namespace: string, id: string): Promise<ISecret | undefined>;
+  get(
+    token: symbol,
+    namespace: string,
+    id: string
+  ): Promise<ISecret | undefined>;
   /**
    * Set a secret given its namespace and ID.
    */
-  set(namespace: string, id: string, secret: ISecret): Promise<any>;
+  set(
+    token: symbol,
+    namespace: string,
+    id: string,
+    secret: ISecret
+  ): Promise<any>;
   /**
    * Remove a secret given its namespace and ID.
    */
-  remove(namespace: string, id: string): Promise<void>;
+  remove(token: symbol, namespace: string, id: string): Promise<void>;
   /**
    * List the secrets for a namespace as a ISecretsList.
    */
-  list(namespace: string): Promise<ISecretsList | undefined>;
+  list(token: symbol, namespace: string): Promise<ISecretsList | undefined>;
   /**
    * Attach an input to the secrets manager, with its namespace and ID values.
    * An optional callback function can be attached too, which be called when the input
    * is programmatically filled.
    */
   attach(
+    token: symbol,
     namespace: string,
     id: string,
     input: HTMLInputElement,
@@ -65,11 +76,20 @@ export interface ISecretsManager {
   /**
    * Detach the input previously attached with its namespace and ID.
    */
-  detach(namespace: string, id: string): void;
+  detach(token: symbol, namespace: string, id: string): void;
   /**
    * Detach all attached input for a namespace.
    */
-  detachAll(namespace: string): Promise<void>;
+  detachAll(token: symbol, namespace: string): Promise<void>;
+}
+
+export namespace ISecretsManager {
+  /**
+   * The plugin factory.
+   * The argument of the factory is a symbol (unique identifier), and it returns a
+   * plugin.
+   */
+  export type PluginFactory<T> = (token: symbol) => JupyterFrontEndPlugin<T>;
 }
 
 /**

--- a/src/token.ts
+++ b/src/token.ts
@@ -76,7 +76,7 @@ export interface ISecretsManager {
   /**
    * Detach the input previously attached with its namespace and ID.
    */
-  detach(token: symbol, namespace: string, id: string): void;
+  detach(token: symbol, namespace: string, id: string): Promise<void>;
   /**
    * Detach all attached input for a namespace.
    */

--- a/src/token.ts
+++ b/src/token.ts
@@ -33,7 +33,7 @@ export interface ISecretsManager {
    *
    * NOTE:
    * If several extensions try to set the connector, the manager will be locked.
-   * This is to prevent malicious extensions to get passwords when they are saved.
+   * This is to prevent misconfiguration of competing plugins or MITM attacks.
    */
   setConnector(value: ISecretsConnector): void;
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2229,7 +2229,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jupyterlab/coreutils@npm:^6.3.5":
+"@jupyterlab/coreutils@npm:^6.0.0, @jupyterlab/coreutils@npm:^6.3.5":
   version: 6.3.5
   resolution: "@jupyterlab/coreutils@npm:6.3.5"
   dependencies:
@@ -6801,6 +6801,7 @@ __metadata:
   dependencies:
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/builder": ^4.0.0
+    "@jupyterlab/coreutils": ^6.0.0
     "@jupyterlab/statedb": ^4.0.0
     "@jupyterlab/testutils": ^4.0.0
     "@lumino/algorithm": ^2.0.0


### PR DESCRIPTION
This PR aims to isolate the secrets from others extensions.

It includes two main ideas to prevent other extensions from recovering or defining secrets that don't belong to them.

1. Do not expose the `SecretsConnector`.
    Before this PR, the secrets connector was exposed by a token, that was consumed by the `SecretsManager`. This token could therefore be consumed by any other extension, which could fetch the secrets of a any namespace.
    With this PR, the secrets connector must be set to the secrets manager by the plugin itself. If several plugins try to set a connector, the manager is locked.

2. Allow only one extension per namespace (**credit to @afshin for the idea and its implementation**).
    When a plugin want to use a namespace with the secrets manager, it has to 'sign in' and get a unique token. This token is required anytime the plugin needs to interact with the `SecretsConnector` (`get`, `set`, `list` or `remove` secrets).
    The secrets manager should be the only one able to access the `Map` objects that keep the relationship between the token and the namespace. To do so, it uses a private namespace that stores:
    - the namespace/token relationship
    - the locked status
    - the connector to use 

Should fix #12 

### How to use it

```ts
const PLUGIN_ID = 'my-extension:my-plugin';
const testing: JupyterFrontEndPlugin<void> = SecretsManager.sign(
  PLUGIN_ID,
  token => ({
    id: PLUGIN_ID,
    requires: [ISecretsManager],
    autoStart: true,
    activate: (app: JupyterFrontEnd, manager: ISecretsManager): void => {
      // Set the secret
      manager.set(token, PLUGIN_ID, 'secretID', {
        namespace: PLUGIN_ID,
        id: 'secretID',
        value: 'secret-value'
      });

      // Get the secret
      const secret = await manager.get(token, PLUGIN_ID, 'secretID');
    }
  })
);
```

If the token is used in an object, for privacy it should also use a `Private` namespace to be stored.

cc. @afshin @jtpio @trungleduc 