### PR TITLE
Do not throw if the secrets manager is disabled

### DIFF
--- a/src/manager.ts
+++ b/src/manager.ts
@@ -255,7 +255,8 @@ export namespace SecretsManager {
     if (isDisabled('jupyter-secrets-manager:manager')) {
       // If the secrets manager is disabled, we need to lock the manager, but not
       // throw an error, to let the plugin get activated anyway.
-      lock('Secret registry is disabled.', false);
+      console.warn('Secrets manager is disabled.');
+      lock();
     }
     if (isDisabled(id)) {
       lock(`Sign error: plugin ${id} is disabled.`);
@@ -295,12 +296,10 @@ namespace Private {
    *
    * @param message - the error message to throw.
    */
-  export function lock(message: string, throwError = true): void {
+  export function lock(message?: string): void {
     locked = true;
-    if (throwError) {
+    if (message) {
       throw new Error(message);
-    } else {
-      console.warn(message);
     }
   }
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -253,7 +253,9 @@ export namespace SecretsManager {
       throw new Error('Secrets manager is locked, check errors.');
     }
     if (isDisabled('jupyter-secrets-manager:manager')) {
-      lock('Secret registry is disabled.');
+      // If the secrets manager is disabled, we need to lock the manager, but not
+      // throw an error, to let the plugin get activated anyway.
+      lock('Secret registry is disabled.', false);
     }
     if (isDisabled(id)) {
       lock(`Sign error: plugin ${id} is disabled.`);
@@ -293,9 +295,13 @@ namespace Private {
    *
    * @param message - the error message to throw.
    */
-  export function lock(message: string) {
+  export function lock(message: string, throwError = true): void {
     locked = true;
-    throw new Error(message);
+    if (throwError) {
+      throw new Error(message);
+    } else {
+      console.warn(message);
+    }
   }
 
   /**


### PR DESCRIPTION
To be able to use the secrets manager, the plugin need to sign before being activated. But we could still expect the extension to be activated without it.
The `sign` function throw if the secrets manager is disabled, which prevents the plugins to get activated without the secrets manager activated.

This PR only warns if the manager is disabled, leaving the plugin concerned to manage its own secrets.

cc. @afshin who was the first to implement the `sign` function.